### PR TITLE
Show the opening variant in the "Rules" column

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -57,6 +57,11 @@
 		return `${k1}.${k2}`;
 	}
 
+	// Title-case the stored PTN opening value, e.g. "double black stack" -> "Double Black Stack".
+	function formatOpening(opening: string) {
+		return opening.replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
 	function formatRatingChange(change: number) {
 		let sign = '+';
 		if (change < 0) {
@@ -176,6 +181,10 @@
 					</span>
 					<span v-if="hasPieceVariation(props.row)">
 						Pieces: {{props.row.pieces}}/{{props.row.capstones}}
+						<br>
+					</span>
+					<span v-if="props.row.opening && props.row.opening !== 'swap'">
+						{{ formatOpening(props.row.opening) }}
 					</span>
 				</q-td>
 				<q-td key="clock" :props="props">


### PR DESCRIPTION
Surfaces a game's **opening variant** in the games-history table's existing **Rules** column, shown only when it isn't the default `swap` (currently just **Double Black Stack**).

The value follows [PTN Ninja](https://ptn.ninja)'s `[Opening "..."]` header tag — the same string the API stores and returns — title-cased for display (`double black stack` → `Double Black Stack`).

Depends on the companion `playtak-api` PR, which adds the `opening` column and exposes it through the games-history API.

#### Changes
- `Table.vue`: added an opening line to the **Rules** column cell, rendered only when `opening` is set and not `swap`, plus a `formatOpening()` helper to title-case the stored value.

#### Compatibility
Legacy games default to `swap` and show nothing extra in the Rules column.